### PR TITLE
Fix MoveIt API change error for attempts

### DIFF
--- a/ur10_e_moveit_config/config/kinematics.yaml
+++ b/ur10_e_moveit_config/config/kinematics.yaml
@@ -2,4 +2,3 @@ manipulator:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3

--- a/ur10_moveit_config/config/kinematics.yaml
+++ b/ur10_moveit_config/config/kinematics.yaml
@@ -2,9 +2,7 @@
 #  kinematics_solver: ur_kinematics/UR10KinematicsPlugin
 #  kinematics_solver_search_resolution: 0.005
 #  kinematics_solver_timeout: 0.005
-#  kinematics_solver_attempts: 3
 manipulator:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3

--- a/ur3_e_moveit_config/config/kinematics.yaml
+++ b/ur3_e_moveit_config/config/kinematics.yaml
@@ -2,4 +2,3 @@ manipulator:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3

--- a/ur3_moveit_config/config/kinematics.yaml
+++ b/ur3_moveit_config/config/kinematics.yaml
@@ -2,9 +2,7 @@
 #  kinematics_solver: ur_kinematics/UR3KinematicsPlugin
 #  kinematics_solver_search_resolution: 0.005
 #  kinematics_solver_timeout: 0.005
-#  kinematics_solver_attempts: 3
 manipulator:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3

--- a/ur5_e_moveit_config/config/kinematics.yaml
+++ b/ur5_e_moveit_config/config/kinematics.yaml
@@ -2,4 +2,3 @@ manipulator:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3

--- a/ur5_moveit_config/config/kinematics.yaml
+++ b/ur5_moveit_config/config/kinematics.yaml
@@ -2,9 +2,7 @@
 #  kinematics_solver: ur_kinematics/UR5KinematicsPlugin
 #  kinematics_solver_search_resolution: 0.005
 #  kinematics_solver_timeout: 0.005
-#  kinematics_solver_attempts: 3
 manipulator:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3


### PR DESCRIPTION
Fixes 'Kinematics solver doesn't support #attempts anymore, but only a timeout.'

See also https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/84