### PR TITLE
Fix default value of kinematics_config for ur10e and ur16e

### DIFF
--- a/ur_e_description/urdf/ur10e_robot.urdf.xacro
+++ b/ur_e_description/urdf/ur10e_robot.urdf.xacro
@@ -9,7 +9,7 @@
   <xacro:include filename="$(find ur_e_description)/urdf/ur10e.urdf.xacro" />
 
   <!-- arm -->
-  <xacro:arg name="kinematics_config" default="$(find ur_description)/config/ur10_default.yaml"/>
+  <xacro:arg name="kinematics_config" default="$(find ur_e_description)/config/ur10e_default.yaml"/>
   <xacro:ur10e_robot prefix="" joint_limited="false"
     kinematics_file="${load_yaml('$(arg kinematics_config)')}"
   />

--- a/ur_e_description/urdf/ur16e_robot.urdf.xacro
+++ b/ur_e_description/urdf/ur16e_robot.urdf.xacro
@@ -9,7 +9,7 @@
   <xacro:include filename="$(find ur_e_description)/urdf/ur16e.urdf.xacro" />
 
   <!-- arm -->
-  <xacro:arg name="kinematics_config" default="$(find ur_description)/config/ur16_default.yaml"/>
+  <xacro:arg name="kinematics_config" default="$(find ur_e_description)/config/ur16e_default.yaml"/>
   <xacro:ur16e_robot prefix="" joint_limited="false"
     kinematics_file="${load_yaml('$(arg kinematics_config)')}"
   />


### PR DESCRIPTION
The default value of `kinematics_config` in `ur10e_robot.urdf.xacro` and `ur16e_robot.urdf.xacro` seems to point to the CB-series description package.

I'm assuming this is a copy-paste error, as there is no CB-series ur16. The default values for ur3e and ur5e are correct.